### PR TITLE
플레이어 색과 사다리색 매칭

### DIFF
--- a/Assets/Prefabs/Ladder.prefab
+++ b/Assets/Prefabs/Ladder.prefab
@@ -229,6 +229,7 @@ MonoBehaviour:
   NestedObjects: []
   NetworkedBehaviours:
   - {fileID: 3998548520461581271}
+  - {fileID: 6353976127107289416}
   SimulationBehaviours: []
 --- !u!114 &3998548520461581271
 MonoBehaviour:
@@ -270,8 +271,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dd50bd65f3ad42443b915911627f060e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _interpolationDataSource: 0
   _ladderSpawnPos: {fileID: 437547577577264914}
   Outline: {fileID: 4671693651663714584}
+  SR: {fileID: 2082568474500481589}
+  _LadderColor: {r: 0, g: 0, b: 0, a: 0}
 --- !u!61 &1228473911976097151
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Ladder.cs
+++ b/Assets/Scripts/Ladder.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Ladder : MonoBehaviour
+public class Ladder : NetworkBehaviour
 {
     private Ladder _prevLadder;
     private Ladder _nextLadder;
@@ -16,6 +16,23 @@ public class Ladder : MonoBehaviour
     public GameObject Outline;
 
     public PlayerLadderController Owner { get; set; }
+
+    public SpriteRenderer SR;
+
+
+    [Networked]
+    public Color LadderColor { get; set; }
+
+
+    private void Start()
+    {
+        SR.color = LadderColor;
+    }
+    public override void Spawned()
+    {
+        base.Spawned();
+        SR.color = LadderColor;
+    }
 
     private void OnTriggerEnter2D(Collider2D collision)
     {

--- a/Assets/Scripts/Player/PlayerLadderController.cs
+++ b/Assets/Scripts/Player/PlayerLadderController.cs
@@ -20,6 +20,9 @@ public class PlayerLadderController : NetworkBehaviour
 
     //Outline
     GameObject _lastLadderObject;
+
+    Color playerColor;
+
     private void OnDrawGizmos()
     {
         Gizmos.color = Color.yellow;
@@ -31,6 +34,7 @@ public class PlayerLadderController : NetworkBehaviour
         base.Spawned();
         _ladderInstallTimer = TickTimer.CreateFromSeconds(Runner, 0);
         _ladderRecallTimer = TickTimer.CreateFromSeconds(Runner, 0);
+        playerColor = GetComponentInChildren<PlayerBehaviour>().PlayerColor;
     }
 
     public override void FixedUpdateNetwork()
@@ -48,6 +52,7 @@ public class PlayerLadderController : NetworkBehaviour
                 if(col == null) ladder = LadderManager.Instance.InstallLadder(this, transform);
                 else ladder = LadderManager.Instance.InstallContinuedLadder(this, col.gameObject.GetComponentInChildren<Ladder>());
 
+                ladder.LadderColor = playerColor;
                 _myLadders.Add(ladder);
 
                 _ladderInstallTimer = TickTimer.CreateFromSeconds(Runner, _installCooltime);


### PR DESCRIPTION
### 개요
- 사다리 색과 플레이어 색이 같도록 제작

### 작업 내용
- 사다리에 Networked Color 변수를 실행하고, Spawned와, Start에서 실행해 각각 로컬, 리모트에서 모두 적용되도록 제작함

https://github.com/hsh0517/LadderMan/assets/82389915/6a20f7a7-9317-4c56-94f7-72fbd07707f6


